### PR TITLE
Add slight ingestion delay and health route.

### DIFF
--- a/function.go
+++ b/function.go
@@ -1,14 +1,32 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httputil"
+	"time"
 )
 
-type HttpRequestDumper struct{}
+func health(w http.ResponseWriter, r *http.Request) {
+	val := `
+                    888 888             888
+                    888 888             888
+                    888 888             888
+888d888 .d88b.  .d88888 88888b.  8888b. 888888
+888P"  d8P  Y8bd88" 888 888 "88b    "88b888
+888    88888888888  888 888  888.d888888888
+888    Y8b.    Y88b 888 888  888888  888Y88b.
+888     "Y8888  "Y88888 888  888"Y888888 "Y888
+`
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, val)
+}
 
-func (md *HttpRequestDumper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func dump(w http.ResponseWriter, r *http.Request) {
+	// Simulate at least a bit of processing time.
+	time.Sleep(100 * time.Millisecond)
+
 	w.WriteHeader(http.StatusOK)
 	if reqBytes, err := httputil.DumpRequest(r, true); err == nil {
 		log.Printf("Openshift Http Request Dumper received a message: %+v", string(reqBytes))
@@ -19,5 +37,9 @@ func (md *HttpRequestDumper) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	http.ListenAndServe(":8080", &HttpRequestDumper{})
+	m := http.NewServeMux()
+	m.HandleFunc("/", dump)
+	m.HandleFunc("/health", health)
+
+	http.ListenAndServe(":8080", m)
 }


### PR DESCRIPTION
1. A slight ingestion delay might be needed to show off the scaling capabilities in smaller demo scenarios.
2. Added a health route which greets the user when doing a "manual" curl.